### PR TITLE
Fix unit tests

### DIFF
--- a/ops_openstack.py
+++ b/ops_openstack.py
@@ -49,17 +49,19 @@ class OSBaseCharm(CharmBase):
 
     REQUIRED_RELATIONS = []
 
-    def __init__(self, framework, key):
-        super().__init__(framework, key)
+    def __init__(self, framework):
+        super().__init__(framework)
         self.state.set_default(is_started=False)
         self.state.set_default(is_paused=False)
         self.state.set_default(series_upgrade=False)
-        self.framework.observe(self.on.install, self)
-        self.framework.observe(self.on.update_status, self)
-        self.framework.observe(self.on.pause_action, self)
-        self.framework.observe(self.on.resume_action, self)
-        self.framework.observe(self.on.pre_series_upgrade, self)
-        self.framework.observe(self.on.post_series_upgrade, self)
+        self.framework.observe(self.on.install, self.on_install)
+        self.framework.observe(self.on.update_status, self.on_update_status)
+        self.framework.observe(self.on.pause_action, self.on_pause_action)
+        self.framework.observe(self.on.resume_action, self.on_resume_action)
+        self.framework.observe(self.on.pre_series_upgrade,
+                               self.on_pre_series_upgrade)
+        self.framework.observe(self.on.post_series_upgrade,
+                               self.on_post_series_upgrade)
 
     def install_pkgs(self):
         logging.info("Installing packages")


### PR DESCRIPTION
All tests are currently failing with

```
$ tox
[...]
unit_tests.test_ops_openstack.TestOSBaseCharm.test_update_status_series_upgrade
-------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/ubuntu/Documents/git/ops-openstack/unit_tests/test_ops_openstack.py", line 184, in test_update_status_series_upgrade
    self.harness.begin()

      File "/home/ubuntu/Documents/git/ops-openstack/.tox/py3/lib/python3.6/site-packages/ops/testing.py", line 135, in begin
    self._charm = TestCharm(self._framework)

    TypeError: __init__() missing 1 required positional argument: 'key'
```

and

```
$ tox
[...]
unit_tests.test_ops_openstack.TestOSBaseCharm.test_update_status_series_upgrade
-------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/ubuntu/Documents/git/ops-openstack/unit_tests/test_ops_openstack.py", line 184, in test_update_status_series_upgrade
    self.harness.begin()

      File "/home/ubuntu/Documents/git/ops-openstack/.tox/py3/lib/python3.6/site-packages/ops/testing.py", line 135, in begin
    self._charm = TestCharm(self._framework)

      File "/home/ubuntu/Documents/git/ops-openstack/ops_openstack.py", line 57, in __init__
    self.framework.observe(self.on.install, self)

      File "/home/ubuntu/Documents/git/ops-openstack/.tox/py3/lib/python3.6/site-packages/ops/framework.py", line 667, in observe
    bound_event.event_kind))

    TypeError: observer methods must now be explicitly provided; please replace observe(self.on.install, self) with e.g. observe(self.on.install, self._on_install)
```
