### PR TITLE
Stop using ops.model.ModelBackend

### DIFF
--- a/ops_openstack.py
+++ b/ops_openstack.py
@@ -2,7 +2,6 @@ from ops.charm import CharmBase
 from ops.framework import (
     StoredState,
 )
-import ops.model
 
 from charmhelpers.fetch import (
     apt_install,
@@ -15,6 +14,7 @@ from ops.model import (
     MaintenanceStatus,
     WaitingStatus,
 )
+import charmhelpers.core.hookenv as hookenv
 import charmhelpers.contrib.openstack.utils as os_utils
 import logging
 
@@ -222,13 +222,15 @@ def get_charm_instance(release=None, package_type='deb', all_releases=None,
 
 def get_charm_class_for_release():
     _origin = None
-    current_model = ops.model.ModelBackend()
-    config = current_model.config_get()
+    # There is no charm class to interact with the ops framework yet
+    # and it is now forbidden to access ops.model._Model so fallback
+    # to charmhelpers.core.hookenv
+    config = hookenv.config()
     if 'source' in config:
         _origin = config['source']
     elif 'openstack-origin' in config:
         _origin = config['openstack-origin']
-    else:
+    if not _origin:
         _origin = 'distro'
     # XXX Make this support openstack and ceph
     target_release = os_utils.get_os_codename_install_source(_origin)

--- a/unit_tests/test_ops_openstack.py
+++ b/unit_tests/test_ops_openstack.py
@@ -94,24 +94,6 @@ class TestOSBaseCharm(CharmTestCase):
                 resume:
                     description: resume action
             ''')
-#        # BEGIN: Workaround until
-#        # https://github.com/canonical/operator/pull/196 lands
-#        class _TestingOPSModelBackend(_TestingModelBackend):
-#
-#            def relation_ids(self, relation_name):
-#                return self._relation_ids_map.get(relation_name, [])
-#        self.harness._backend = _TestingOPSModelBackend(
-#            self.harness._unit_name)
-#        self.harness._model = model.Model(
-#            self.harness._unit_name,
-#            self.harness._meta,
-#            self.harness._backend)
-#        self.harness._framework = framework.Framework(
-#            ":memory:",
-#            self.harness._charm_dir,
-#            self.harness._meta,
-#            self.harness._model)
-#        # END Workaround
 
     def test_init(self):
         self.harness.begin()


### PR DESCRIPTION
ops.model.ModelBackend has been marked private *1 so fallback to
using charmhelpers to get the runtime config.

*1 https://github.com/canonical/operator/blob/master/ops/model.py#L952